### PR TITLE
Refactor school search URLs in NetSchoolAPI

### DIFF
--- a/netschoolapi/netschoolapi.py
+++ b/netschoolapi/netschoolapi.py
@@ -306,7 +306,7 @@ class NetSchoolAPI:
         resp = await self._wrapped_client.request(
             requests_timeout,
             self._wrapped_client.client.build_request(
-                method="GET", url="schools/search",
+                method="GET", url="schools/search?name=Y",
             )
         )
         schools = schemas.ShortSchoolSchema().load(resp.json(), many=True)
@@ -318,7 +318,7 @@ class NetSchoolAPI:
         schools = (await requester(
             self._wrapped_client.client.build_request(
                 method="GET",
-                url="schools/search",
+                url=f"schools/search?name={school_name}",
             )
         )).json()
 

--- a/netschoolapi/netschoolapi.py
+++ b/netschoolapi/netschoolapi.py
@@ -306,7 +306,7 @@ class NetSchoolAPI:
         resp = await self._wrapped_client.request(
             requests_timeout,
             self._wrapped_client.client.build_request(
-                method="GET", url="schools/search?name=Y",
+                method="GET", url="schools/search?name=У",
             )
         )
         schools = schemas.ShortSchoolSchema().load(resp.json(), many=True)


### PR DESCRIPTION
В новых версиях нельзя получить весь список школ поэтому нужно указывать параметр `name`. Не уверен что это самый лучший вариант, но вроде бы у чела в чате ( https://t.me/netschoolapi/2387 ) сработало